### PR TITLE
Fixing squid: S2696 instance methods should not write to static fields

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,16 +1,17 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 21
-    buildToolsVersion "21.1.2"
-
+    compileSdkVersion 23
+    buildToolsVersion "23.0.3"
+    useLibrary 'org.apache.http.legacy'
     defaultConfig {
-        applicationId "menudroid.aybars.arslan.menudroid"
-        minSdkVersion 14
-        targetSdkVersion 21
+        applicationId "com.example.teknopc.myapplication"
+        minSdkVersion 23
+        targetSdkVersion 23
         versionCode 1
         versionName "1.0"
     }
+
     buildTypes {
         release {
             minifyEnabled false
@@ -19,19 +20,13 @@ android {
     }
 }
 
-repositories {
-    mavenCentral()
-
-    maven {
-        url "http://dl.bintray.com/journeyapps/maven"
-    }
-}
-
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:21.0.+'
-    //  Material Dialogs -barcode
-    compile 'com.afollestad:material-dialogs:0.6.3.5'
+    testCompile 'junit:junit:4.12'
+    compile 'com.android.support:appcompat-v7:23.1.0'
+
+    compile('com.github.afollestad.material-dialogs:core:0.8.5.8@aar') { transitive = true }
+    compile('com.github.afollestad.material-dialogs:commons:0.8.5.8@aar')
     //  Spinner
     compile 'com.github.navasmdc:MaterialDesign:1.+@aar'
 
@@ -50,4 +45,16 @@ dependencies {
     // This mostly affects encoding, but you should test if you plan to support these versions.
     // Older versions e.g. 2.2 may also work if you need support for older Android versions.
     compile 'com.google.zxing:core:3.0.1'
+
+
+
 }
+
+repositories {
+    mavenCentral()
+
+    maven {
+        url "http://dl.bintray.com/journeyapps/maven"
+    }
+}
+

--- a/app/src/main/java/menudroid/aybars/arslan/menudroid/MainActivity.java
+++ b/app/src/main/java/menudroid/aybars/arslan/menudroid/MainActivity.java
@@ -65,14 +65,16 @@ public class MainActivity extends ActionBarActivity implements SocketServerTask.
         if( savedInstanceState != null ) {
             //recovering the states
             qrComplement=savedInstanceState.getString("qrComplement");
-            qrResult=savedInstanceState.getString("qrResult");
+            setQrResult(savedInstanceState.getString("qrResult"));
         }
         setContentView(R.layout.activity_main);
 
         // Initalize buttons
         initialize();
     }
-
+    private static void setQrResult(String data) {
+       qrResult=data;
+    }
     private void initialize() {
         btnOrder = (Button) findViewById(R.id.btnOrder);
         btnBill = (Button) findViewById(R.id.btnBill);
@@ -183,7 +185,7 @@ public class MainActivity extends ActionBarActivity implements SocketServerTask.
                     @Override
                     public void onClick(DialogInterface dialog, int which) {
                         String ipData = etIP.getEditableText().toString().trim();
-                        SERVER_IP = ipData;
+                        setServerIp(ipData);
                         Editor editor = ipPrefrence.edit();
                         editor.putString("ipData",ipData);
                         editor.commit();
@@ -201,7 +203,9 @@ public class MainActivity extends ActionBarActivity implements SocketServerTask.
                 .show();
 
     }
-
+    private static void   setServerIp(String ipData){
+        SERVER_IP=ipData;
+    }
     private void showDialogMenu(){
         AlertDialogWrapper.Builder dialogBuilder = new AlertDialogWrapper.Builder(this);
         dialogBuilder.setMessage(R.string.main_menu_message);
@@ -335,7 +339,7 @@ public class MainActivity extends ActionBarActivity implements SocketServerTask.
 
                 String re = scanResult.getContents(); // getScan result
                 Log.i("table", re);
-                qrResult = re;
+                setQrResult(re);
                 sendRequest();
             } catch (NullPointerException e) {
                 e.printStackTrace();

--- a/build.gradle
+++ b/build.gradle
@@ -3,9 +3,12 @@
 buildscript {
     repositories {
         jcenter()
+
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.1.0'
+        classpath 'com.android.tools.build:gradle:2.1.0'
+        classpath 'com.github.dcendents:android-maven-gradle-plugin:1.3'
+        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.4'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
@@ -15,5 +18,6 @@ buildscript {
 allprojects {
     repositories {
         jcenter()
+          maven { url "https://jitpack.io" }
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Apr 10 15:27:10 PDT 2013
+#Sun May 22 20:31:29 EEST 2016
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.2.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.13-all.zip


### PR DESCRIPTION
 This pull request is focused on resolving occurrences of Sonar rule 
 squid:S2696 - “Instance methods should not write to static fields”. 
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S2696
This PR will remove 60min TD from the application.
 Please let me know if you have any questions.
 Fevzi Ozgul
