### PR TITLE
Fixing squid: S1148 Throwable.printStackTrace(...) should not be called

### DIFF
--- a/app/src/main/java/menudroid/aybars/arslan/menudroid/MainActivity.java
+++ b/app/src/main/java/menudroid/aybars/arslan/menudroid/MainActivity.java
@@ -25,6 +25,8 @@ import com.google.zxing.integration.android.IntentResult;
 import org.json.JSONObject;
 
 import java.net.InetAddress;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import menudroid.aybars.arslan.menudroid.asyncs.SocketServerTask;
 import menudroid.aybars.arslan.menudroid.db.SqlOperations;
@@ -338,7 +340,7 @@ public class MainActivity extends ActionBarActivity implements SocketServerTask.
                 qrResult = re;
                 sendRequest();
             } catch (NullPointerException e) {
-                e.printStackTrace();
+                Log.d("ERROR",e.toString());
             }
 
     }

--- a/app/src/main/java/menudroid/aybars/arslan/menudroid/asyncs/SocketServerTask.java
+++ b/app/src/main/java/menudroid/aybars/arslan/menudroid/asyncs/SocketServerTask.java
@@ -78,7 +78,7 @@ public class SocketServerTask extends AsyncTask<JSONObject, Void, String> {
                 socket.close();
 
             } catch (IOException e) {
-                e.printStackTrace();
+                Log.e("ERROR",""+e.toString());
                 success = false;
             } finally {
 
@@ -88,7 +88,6 @@ public class SocketServerTask extends AsyncTask<JSONObject, Void, String> {
                         Log.i(TAG, "closing the socket");
                         socket.close();
                     } catch (IOException e) {
-                        e.printStackTrace();
                         Log.e("ERROR",""+e.toString());
                     }
                 }
@@ -98,7 +97,6 @@ public class SocketServerTask extends AsyncTask<JSONObject, Void, String> {
                     try {
                         dataInputStream.close();
                     } catch (IOException e) {
-                        e.printStackTrace();
                         Log.e("ERROR",""+e.toString());
                     }
                 }
@@ -108,7 +106,6 @@ public class SocketServerTask extends AsyncTask<JSONObject, Void, String> {
                     try {
                         dataOutputStream.close();
                     } catch (IOException e) {
-                        e.printStackTrace();
                         Log.e("ERROR",""+e.toString());
                     }
                 }

--- a/app/src/main/java/menudroid/aybars/arslan/menudroid/main/MenuActivity.java
+++ b/app/src/main/java/menudroid/aybars/arslan/menudroid/main/MenuActivity.java
@@ -148,8 +148,7 @@ public class MenuActivity extends ActionBarActivity implements SocketServerTask.
                 food.put("quantity", quantity);
                 food.put("food_name", food_name);
             } catch (JSONException e) {
-                // TODO Auto-generated catch block
-                e.printStackTrace();
+                Log.d("ERROR",e.toString());
             }
             jsonArray.put(food);
 
@@ -310,12 +309,12 @@ public class MenuActivity extends ActionBarActivity implements SocketServerTask.
                 sb.append(line);
             }
         } catch (IOException e) {
-            e.printStackTrace();
+            Log.d("ERROR",e.toString());
         } finally {
             try {
                 is.close();
             } catch (IOException e) {
-                e.printStackTrace();
+                Log.d("ERROR",e.toString());
             }
         }
         return sb.toString();

--- a/app/src/main/java/menudroid/aybars/arslan/menudroid/ui/SplashScreen.java
+++ b/app/src/main/java/menudroid/aybars/arslan/menudroid/ui/SplashScreen.java
@@ -6,6 +6,7 @@ package menudroid.aybars.arslan.menudroid.ui;
 import android.content.Intent;
 import android.support.v7.app.ActionBarActivity;
 import android.os.Bundle;
+import android.util.Log;
 
 import menudroid.aybars.arslan.menudroid.MainActivity;
 import menudroid.aybars.arslan.menudroid.R;
@@ -28,7 +29,7 @@ public class SplashScreen extends ActionBarActivity {
                 try {
                     sleep(1000);// 4 second wait
                 } catch (InterruptedException e) {
-                    e.printStackTrace();
+                    Log.d("ERROR",e.toString());
                 } finally {
                     Intent intent = new Intent(SplashScreen.this, MainActivity.class);
                     startActivity(intent);


### PR DESCRIPTION
 This pull request is focused on resolving occurrences of Sonar rule 
 squid:S1148 - “Throwable.printStackTrace(...) should not be called”. 
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S1148
 TD removed: 80min
 Please let me know if you have any questions.
 Fevzi Ozgul
