### PR TITLE
Fixing squid:SwitchLastCaseIsDefaultCheck  "switch" statements shouldend with a "default" clause

### DIFF
--- a/app/src/main/java/menudroid/aybars/arslan/menudroid/MainActivity.java
+++ b/app/src/main/java/menudroid/aybars/arslan/menudroid/MainActivity.java
@@ -158,6 +158,8 @@ public class MainActivity extends ActionBarActivity implements SocketServerTask.
                 Log.i("Clicked:", imgSetIP.toString());
                 showDialogIp();//Define the IP change dialog
                 break;
+            default:
+                break;
         }
 
     }

--- a/app/src/main/java/menudroid/aybars/arslan/menudroid/db/SqlOperations.java
+++ b/app/src/main/java/menudroid/aybars/arslan/menudroid/db/SqlOperations.java
@@ -183,6 +183,8 @@ public class SqlOperations {
                         row.put(KEY_QTY, oldQty - 1);//substract -1 if the qty is greater than 0,
                     database.update(SqliteConnection.TABLE_NAME, row, "_id=" + idSum, null); //update qty DB the request
                     break;
+                default:
+                    break;
             }
         }
 

--- a/app/src/main/java/menudroid/aybars/arslan/menudroid/main/MenuActivity.java
+++ b/app/src/main/java/menudroid/aybars/arslan/menudroid/main/MenuActivity.java
@@ -109,7 +109,8 @@ public class MenuActivity extends ActionBarActivity implements SocketServerTask.
             case R.id.fab:
                 showDialogOrder();
                 break;
-
+            default:
+                break;
         }
     }
 


### PR DESCRIPTION
 This pull request is focused on resolving occurrences of Sonar rule 
 squid:SwitchLastCaseIsDefaultCheck - "switch" statements shouldend with a "default" clause”. 
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:SwitchLastCaseIsDefaultCheck
 Please let me know if you have any questions.
Fevz Ozgul
