### PR TITLE
Fixing squid: S1166  Exception handlers should preserve the original exception

### DIFF
--- a/app/src/main/java/menudroid/aybars/arslan/menudroid/MainActivity.java
+++ b/app/src/main/java/menudroid/aybars/arslan/menudroid/MainActivity.java
@@ -345,6 +345,7 @@ public class MainActivity extends ActionBarActivity implements SocketServerTask.
                 sendRequest();
             } catch (NullPointerException e) {
                 Log.d("ERROR",e.toString());
+                throw new RuntimeException(e);
             }
 
     }

--- a/app/src/main/java/menudroid/aybars/arslan/menudroid/asyncs/SocketServerTask.java
+++ b/app/src/main/java/menudroid/aybars/arslan/menudroid/asyncs/SocketServerTask.java
@@ -80,6 +80,7 @@ public class SocketServerTask extends AsyncTask<JSONObject, Void, String> {
             } catch (IOException e) {
                 Log.e(ERROR,""+e.toString());
                 success = false;
+                throw new RuntimeException(e);
             } finally {
 
                 // close socket
@@ -89,6 +90,7 @@ public class SocketServerTask extends AsyncTask<JSONObject, Void, String> {
                         socket.close();
                     } catch (IOException e) {
                         Log.e(ERROR,""+e.toString());
+                        throw new RuntimeException(e);
                     }
                 }
 
@@ -98,6 +100,7 @@ public class SocketServerTask extends AsyncTask<JSONObject, Void, String> {
                         dataInputStream.close();
                     } catch (IOException e) {
                         Log.e(ERROR,""+e.toString());
+                        throw new RuntimeException(e);
                     }
                 }
 
@@ -107,6 +110,7 @@ public class SocketServerTask extends AsyncTask<JSONObject, Void, String> {
                         dataOutputStream.close();
                     } catch (IOException e) {
                         Log.e(ERROR,""+e.toString());
+                        throw new RuntimeException(e);
                     }
                 }
             }

--- a/app/src/main/java/menudroid/aybars/arslan/menudroid/json/JsonDataToSend.java
+++ b/app/src/main/java/menudroid/aybars/arslan/menudroid/json/JsonDataToSend.java
@@ -19,6 +19,7 @@ public class JsonDataToSend {
            jsonData.put("request", request);
        } catch (JSONException e) {
            e.printStackTrace();
+           throw new RuntimeException(e);
        }
    }
 
@@ -27,6 +28,7 @@ public class JsonDataToSend {
             jsonData.put("messageArray", messageArray);
         } catch (JSONException e) {
             e.printStackTrace();
+            throw new RuntimeException(e);
         }
     }
     public void setMessage(String message){
@@ -34,6 +36,7 @@ public class JsonDataToSend {
             jsonData.put("message", message);
         } catch (JSONException e) {
             e.printStackTrace();
+            throw new RuntimeException(e);
         }
     }
 

--- a/app/src/main/java/menudroid/aybars/arslan/menudroid/main/MenuActivity.java
+++ b/app/src/main/java/menudroid/aybars/arslan/menudroid/main/MenuActivity.java
@@ -155,6 +155,7 @@ public class MenuActivity extends ActionBarActivity implements SocketServerTask.
                 food.put("food_name", food_name);
             } catch (JSONException e) {
                 Log.d(ERROR,e.toString());
+                throw new RuntimeException(e);
             }
             jsonArray.put(food);
 
@@ -279,10 +280,12 @@ public class MenuActivity extends ActionBarActivity implements SocketServerTask.
 
             jsonResponse = e.toString();
             Log.d(EXCEPT, "" + jsonResponse);
+            throw new RuntimeException(e);
         } catch (ConnectTimeoutException e) {
 
             jsonResponse = e.toString();
             Log.d(EXCEPT, "" + jsonResponse);
+            throw new RuntimeException(e);
         } catch (SocketTimeoutException e) {
 
             jsonResponse = e.toString();
@@ -290,10 +293,12 @@ public class MenuActivity extends ActionBarActivity implements SocketServerTask.
         } catch (IOException e) {
             jsonResponse = e.toString();
             Log.d(EXCEPT, "" + jsonResponse);
+            throw new RuntimeException(e);
 
         } catch (Exception e) {
             jsonResponse = e.toString();
             Log.d(EXCEPT, "" + jsonResponse);
+            throw new RuntimeException(e);
         }
     }
 
@@ -310,11 +315,13 @@ public class MenuActivity extends ActionBarActivity implements SocketServerTask.
             }
         } catch (IOException e) {
             Log.d(ERROR,e.toString());
+            throw new RuntimeException(e);
         } finally {
             try {
                 is.close();
             } catch (IOException e) {
                 Log.d(ERROR,e.toString());
+                throw new RuntimeException(e);
             }
         }
         return sb.toString();


### PR DESCRIPTION
 This pull request is focused on resolving occurrences of Sonar rule 
 squid:S1166- “ Exception handlers should preserve the original exception”. 
 You can find more information about the issues here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S1166
 Please let me know if you have any questions.
Fevzi Ozgul
