### PR TITLE
Fixing squid: S1319  Declarations should use Java collection interfaces 

### DIFF
--- a/app/src/main/java/menudroid/aybars/arslan/menudroid/db/SqlOperations.java
+++ b/app/src/main/java/menudroid/aybars/arslan/menudroid/db/SqlOperations.java
@@ -10,6 +10,7 @@ import android.util.Log;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 
 /**
  * Clase para manipular las operaciones simples con db local como son insert,delete,update,etc
@@ -51,10 +52,10 @@ public class SqlOperations {
         database.delete("PriceClient", null, null);
     }
 
-    public ArrayList<HashMap<String, String>> getOrder() {
+    public List<HashMap<String, String>> getOrder() {
 
         Cursor cursor;
-        ArrayList<HashMap<String, String>> allElementsDictionary = new ArrayList<HashMap<String, String>>();
+        List<HashMap<String, String>> allElementsDictionary = new ArrayList<HashMap<String, String>>();
         String select = "SELECT quantity,price,food_name from OrderClient";
         cursor = database.rawQuery(select, null);
         if (cursor.getCount() == 0) // if there are no elements do nothing

--- a/app/src/main/java/menudroid/aybars/arslan/menudroid/main/MenuActivity.java
+++ b/app/src/main/java/menudroid/aybars/arslan/menudroid/main/MenuActivity.java
@@ -120,7 +120,7 @@ public class MenuActivity extends ActionBarActivity implements SocketServerTask.
         //here get the order
         sqliteoperation = new SqlOperations(getApplicationContext());
         sqliteoperation.open();
-        ArrayList<HashMap<String, String>> dictionary = sqliteoperation.getOrder();
+        List<HashMap<String, String>> dictionary = sqliteoperation.getOrder();
         sqliteoperation.close();
 
         String totalbyFood;

--- a/app/src/main/java/menudroid/aybars/arslan/menudroid/main/RestaurantAdapter.java
+++ b/app/src/main/java/menudroid/aybars/arslan/menudroid/main/RestaurantAdapter.java
@@ -8,6 +8,7 @@ import android.widget.ImageView;
 import android.widget.TextView;
 
 import java.util.ArrayList;
+import java.util.List;
 
 import menudroid.aybars.arslan.menudroid.R;
 
@@ -16,8 +17,8 @@ import menudroid.aybars.arslan.menudroid.R;
  */
 public class RestaurantAdapter extends RecyclerView.Adapter<RestaurantAdapter.ViewHolder> {
 
-private ArrayList<RestaurantItem> itemsData;
-    public RestaurantAdapter(ArrayList<RestaurantItem> itemsData) {
+    private List<RestaurantItem> itemsData = new ArrayList<RestaurantItem>();
+    public RestaurantAdapter(List<RestaurantItem> itemsData) {
         this.itemsData = itemsData;
     }
 


### PR DESCRIPTION
 This pull request is focused on resolving occurrences of Sonar rule 
 squid:S1319 - “Declarations should use Java collection interfaces such as ""List"" rather than specific implementation classes such as ""LinkedList"" ”. 
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S1319
 Please let me know if you have any questions.
Fevzi Ozgul
