### PR TITLE
Fixing squid: S1186 Methods should not be empty

### DIFF
--- a/app/src/main/java/menudroid/aybars/arslan/menudroid/MainActivity.java
+++ b/app/src/main/java/menudroid/aybars/arslan/menudroid/MainActivity.java
@@ -383,12 +383,12 @@ public class MainActivity extends ActionBarActivity implements SocketServerTask.
     /* INTERFACE METHODS FROM OurTaskListener-SocketServerTask */
     @Override
     public void onOurTaskStarted() {
-
+        throw new UnsupportedOperationException("This method is not implemented yet.");
     }
 
     @Override
     public void onOurTaskInProcess() {
-
+        throw new UnsupportedOperationException("This method is not implemented yet.");
     }
 
     @Override

--- a/app/src/main/java/menudroid/aybars/arslan/menudroid/db/SqliteConnection.java
+++ b/app/src/main/java/menudroid/aybars/arslan/menudroid/db/SqliteConnection.java
@@ -33,7 +33,7 @@ public class SqliteConnection  extends SQLiteOpenHelper {
     @Override
     public void onUpgrade(SQLiteDatabase db, int oldVersion, int newVersion) {
 
-
+        throw new UnsupportedOperationException("This method is not implemented yet.");
     }
 
 

--- a/app/src/main/java/menudroid/aybars/arslan/menudroid/main/MenuActivity.java
+++ b/app/src/main/java/menudroid/aybars/arslan/menudroid/main/MenuActivity.java
@@ -444,12 +444,12 @@ public class MenuActivity extends ActionBarActivity implements SocketServerTask.
     /* INTERFACE METHODS FROM OurTaskListener-SocketServerTask */
     @Override
     public void onOurTaskStarted() {
-
+        throw new UnsupportedOperationException("This method is not implemented yet.");
     }
 
     @Override
     public void onOurTaskInProcess() {
-
+        throw new UnsupportedOperationException("This method is not implemented yet.");
     }
 
     @Override


### PR DESCRIPTION
 This pull request is focused on resolving occurrences of Sonar rule 
 squid:S1186 - “Methods should not be empty”. 
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S1186
 Please let me know if you have any questions.
 Fevzi Ozgul
