### PR TITLE
Fixing squid: ClassVariableVisibilityCheck Class variable fields should not have public accessibility

### DIFF
--- a/app/src/main/java/menudroid/aybars/arslan/menudroid/main/RestaurantAdapter.java
+++ b/app/src/main/java/menudroid/aybars/arslan/menudroid/main/RestaurantAdapter.java
@@ -49,8 +49,8 @@ private ArrayList<RestaurantItem> itemsData;
     // inner class to hold a reference to each item of RecyclerView
     public static class ViewHolder extends RecyclerView.ViewHolder {
 
-        public TextView txtViewTitle;
-        public ImageView imgViewIcon;
+        private TextView txtViewTitle;
+        private ImageView imgViewIcon;
 
         public ViewHolder(View itemLayoutView) {
             super(itemLayoutView);


### PR DESCRIPTION
 This pull request is focused on resolving occurrences of Sonar rule 
 squid:S1319 - “Class variable fields should not have public accessibility ”. 
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:ClassVariableVisibilityCheck
 Please let me know if you have any questions.
 Fevzi Ozgul
