### PR TITLE
Fixing squid: S106  Standard outputs should not be used directly to log anything

### DIFF
--- a/app/src/main/java/menudroid/aybars/arslan/menudroid/MainActivity.java
+++ b/app/src/main/java/menudroid/aybars/arslan/menudroid/MainActivity.java
@@ -358,10 +358,7 @@ public class MainActivity extends ActionBarActivity implements SocketServerTask.
         jsonDataToSend.setMessage(qrResult);//now the JSON is complete
         jsonData=jsonDataToSend.getOurJson();// pass the json object to this variable.
         String jsonStr = jsonData.toString();
-        System.out.println("jsonString: "+jsonStr);
         Log.d("JSON", jsonStr);
-
-
         //Start the AsyncTask execution
         //Accepted client socket object will pass as the parameter
         serverAsyncTask= new SocketServerTask(this,c);

--- a/app/src/main/java/menudroid/aybars/arslan/menudroid/main/MenuActivity.java
+++ b/app/src/main/java/menudroid/aybars/arslan/menudroid/main/MenuActivity.java
@@ -170,20 +170,11 @@ public class MenuActivity extends ActionBarActivity implements SocketServerTask.
         jsonDataToSend.setMessageJsonArray(jsonArray);//now the JSON is complete
         jsonData = jsonDataToSend.getOurJson();// pass the json object to this variable.
         String jsonStr = jsonData.toString();
-        System.out.println(" the json to sent jsonString: " + jsonStr);
         Log.d("JSON", jsonStr);
-
-
-
-
-
         messageOrder += "\n Total = " + totalbyOrder + "$\n Are you sure the ordered them";
-
         AlertDialogWrapper.Builder dialogBuilder = new AlertDialogWrapper.Builder(this);
         dialogBuilder.setMessage(messageOrder);//R.string.main_order_message)
         dialogBuilder.setTitle(R.string.main_order_title);
-
-
         dialogBuilder.setNegativeButton(R.string.cancel, new DialogInterface.OnClickListener() {
             @Override
             public void onClick(DialogInterface dialog, int which) {


### PR DESCRIPTION
 This pull request is focused on resolving occurrences of Sonar rule 
 squid:S106 - “Standard outputs should not be used directly to log anything”. 
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S106
 Please let me know if you have any questions.
Fevzi Ozgul
