### PR TITLE
Fixing squid: S1143 "return" statements should not occur in "finally" blocks

### DIFF
--- a/app/src/main/java/menudroid/aybars/arslan/menudroid/asyncs/SocketServerTask.java
+++ b/app/src/main/java/menudroid/aybars/arslan/menudroid/asyncs/SocketServerTask.java
@@ -80,7 +80,6 @@ public class SocketServerTask extends AsyncTask<JSONObject, Void, String> {
             } catch (IOException e) {
                 Log.e(ERROR,""+e.toString());
                 success = false;
-                throw new RuntimeException(e);
             } finally {
 
                 // close socket
@@ -90,7 +89,6 @@ public class SocketServerTask extends AsyncTask<JSONObject, Void, String> {
                         socket.close();
                     } catch (IOException e) {
                         Log.e(ERROR,""+e.toString());
-                        throw new RuntimeException(e);
                     }
                 }
 
@@ -100,7 +98,6 @@ public class SocketServerTask extends AsyncTask<JSONObject, Void, String> {
                         dataInputStream.close();
                     } catch (IOException e) {
                         Log.e(ERROR,""+e.toString());
-                        throw new RuntimeException(e);
                     }
                 }
 
@@ -110,7 +107,6 @@ public class SocketServerTask extends AsyncTask<JSONObject, Void, String> {
                         dataOutputStream.close();
                     } catch (IOException e) {
                         Log.e(ERROR,""+e.toString());
-                        throw new RuntimeException(e);
                     }
                 }
             }

--- a/app/src/main/java/menudroid/aybars/arslan/menudroid/main/MenuActivity.java
+++ b/app/src/main/java/menudroid/aybars/arslan/menudroid/main/MenuActivity.java
@@ -300,7 +300,6 @@ public class MenuActivity extends ActionBarActivity implements SocketServerTask.
                 is.close();
             } catch (IOException e) {
                 Log.d(ERROR,e.toString());
-                throw new RuntimeException(e);
             }
         }
         return sb.toString();


### PR DESCRIPTION
This PR is about removing occurences of return statements from finally blocks. 
It will remove 120 min TD .
Fevzi Ozgul
