### PR TITLE
Fixing squid: S1163 Exceptions should not be thrown in finally blocks

### DIFF
--- a/app/src/main/java/menudroid/aybars/arslan/menudroid/asyncs/SocketServerTask.java
+++ b/app/src/main/java/menudroid/aybars/arslan/menudroid/asyncs/SocketServerTask.java
@@ -90,7 +90,6 @@ public class SocketServerTask extends AsyncTask<JSONObject, Void, String> {
                         socket.close();
                     } catch (IOException e) {
                         Log.e(ERROR,""+e.toString());
-                        throw new RuntimeException(e);
                     }
                 }
 
@@ -100,7 +99,6 @@ public class SocketServerTask extends AsyncTask<JSONObject, Void, String> {
                         dataInputStream.close();
                     } catch (IOException e) {
                         Log.e(ERROR,""+e.toString());
-                        throw new RuntimeException(e);
                     }
                 }
 
@@ -110,7 +108,6 @@ public class SocketServerTask extends AsyncTask<JSONObject, Void, String> {
                         dataOutputStream.close();
                     } catch (IOException e) {
                         Log.e(ERROR,""+e.toString());
-                        throw new RuntimeException(e);
                     }
                 }
             }

--- a/app/src/main/java/menudroid/aybars/arslan/menudroid/main/MenuActivity.java
+++ b/app/src/main/java/menudroid/aybars/arslan/menudroid/main/MenuActivity.java
@@ -300,7 +300,6 @@ public class MenuActivity extends ActionBarActivity implements SocketServerTask.
                 is.close();
             } catch (IOException e) {
                 Log.d(ERROR,e.toString());
-                throw new RuntimeException(e);
             }
         }
         return sb.toString();


### PR DESCRIPTION
 This pull request is focused on resolving occurrences of Sonar rule 
 squid:S1163 - “Exceptions should not be thrown in finally blocks ”. 
This PR will remove 2h TD.
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S1149
 Please let me know if you have any questions.
Fevzi Ozgul
